### PR TITLE
Merge squashed changes from HomologyModulo2 branch

### DIFF
--- a/doctests/test_simplex_class.txt
+++ b/doctests/test_simplex_class.txt
@@ -47,4 +47,3 @@ Chain({2-simplex: [1, 2, 3], 2-simplex: [0, 1, 3], 2-simplex: [0, 2, 3], 2-simpl
 True
 >>> v0 in t0.interior
 True
-

--- a/scripts/homology_mod_2.py
+++ b/scripts/homology_mod_2.py
@@ -1,0 +1,18 @@
+from itertools import combinations
+from tda_utilities.simplicial import Simplex, SimplicialComplex
+
+v0, v1, v2 = Simplex('a'), Simplex('b'), Simplex('c')
+e0, e1, e2 = Simplex('a', 'b'), Simplex('a', 'c'), Simplex('b', 'c')
+
+simplicial_circle = SimplicialComplex(v0, v1, v2, e0, e1, e2)
+
+C_0 = [{simplex} for simplex in simplicial_circle.k_chain(0)]
+C_1 = [{simplex} for simplex in simplicial_circle.k_chain(1)]
+
+for n in range(2, 4):
+    for combo in combinations((v0, v1, v2), n):
+        C_0 += [{combo}]
+
+for n in range(2, 4):
+    for combo in combinations((e0, e1, e2), n):
+        C_1 += [{combo}]

--- a/tda_utilities/homology_mod_2.py
+++ b/tda_utilities/homology_mod_2.py
@@ -1,0 +1,42 @@
+"""defines classes and functions for simplicial homology modulo 2"""
+from __future__ import annotations
+from collections import Counter
+
+
+class Chain(set):
+    """defines a boundary of a k-simplex or a simplicial k-complex"""
+    __slots__ = ['_Chain__boundary', '_Chain__k']
+
+    def __init__(self, simplices):
+        self.__boundary = 0  # boundary of boundary is 0
+        super().__init__(simplices)
+        self.__k = max(self).k
+
+    @property
+    def boundary(self) -> int:
+        """the boundary of a boundary"""
+        return self.__boundary
+
+    @property
+    def k(self) -> int:
+        """the dimension of the chain"""
+        return self.__k
+
+    def __add__(self, other) -> Chain:
+        """modulo 2"""
+        if type(other) is not Chain:
+            raise TypeError('k-chain can only be added to another k-chain')
+        elif self.k == other.k:
+            kchain_sum = Counter(self) + Counter(other)
+            mod_2 = {sx for sx, cnt in kchain_sum.items() if cnt % 2}
+        else:
+            raise ValueError('cannot add k-chains of different dimensions')
+        return Chain(mod_2) if mod_2 else 0
+
+
+def boundary(entity, *args, **kwargs) -> Chain:
+    """defines the boundary operator"""
+    bdry = getattr(entity, 'boundary', None)
+    if callable(bdry):
+        return bdry(*args, **kwargs)
+    return bdry


### PR DESCRIPTION
added k_simplices and boundary methods

boundary returns the boundary of the k-simplices in the complex

k_simplices returns the k-simplices in the complex

implemented Boundary class and boundary operatator

Simplex inherits from frozenset

SimplicialComplex inherits from set

Boundary inherits from set

scripts/example.py added

boundary propery of Simplex and boundary() method of SimplicialComplex
now return Boundary objects

removed unnecessary try/except statements

Simplex is now a subclass of frozenset and returns an empty frozenset,
so the | and - operators will now work as long as a simplex is passed in

added doctests

fixed closure method

can now accept a SimplicialComplex or set of simplices as an argument

added doctest and updated closure method

renamed Boundary to KChain

KChain __add__ dunder method

added property k to be checked when the + operator is used on two
KChains. raises error if wrong type or dimension.

new submodule homology_mod_2

KChain renamed to Chain and definition moved to homology_mod_2 along
with boundary function